### PR TITLE
fix: remove traefik from default k3s install causing conflicts with ingress-nginx controller

### DIFF
--- a/ansible/roles/k3s/tasks/install.yml
+++ b/ansible/roles/k3s/tasks/install.yml
@@ -17,5 +17,5 @@
     mode: '0755'
 
 - name: Execute the K3s installation script
-  ansible.builtin.command: /tmp/install_k3s.sh --write-kubeconfig-mode 644
+  ansible.builtin.command: /tmp/install_k3s.sh --disable=traefik --write-kubeconfig-mode 644
   become: false


### PR DESCRIPTION
# 📡 Labops Pull Request Description

## 📋 Description

**Briefly describe the purpose of this PR**: Remove traefik from default k3s install because it was conflicting with ingress-nginx controller

---

## ⚠️ Points of Attention

Are there any specific aspects that need extra attention?
- **Potential impacts on other features or services**: 
- **Breaking changes or migrations required**: 
- **Dependencies or external services involved**: 

---

## 🧪 How to Test

Procedure to test this PR:
1. Clone the branch and navigate to the project folder.
2. Run the following commands:
    ```sh
    export PROJECT_PATH="/opt/homeops/labops"

    # Deploy Ansible
    cd $PROJECT_PATH/ansible \
      && ansible-playbook site.yml --tags preprod -i inventories/main/hosts
    ```
3. Check if the new feature/fix works as expected.
4. Confirm that existing features are not impacted.

---

## 🚀 Deployment

Procedure to deploy this PR to production:
1. Merge this PR into the `master` branch.
2. Ensure the CI/CD pipeline completes successfully.
3. Deploy using the following command:
    ```sh
    export PROJECT_PATH="/opt/homeops/labops"

   # Deploy Ansible
    cd $PROJECT_PATH/ansible \
      && ansible-playbook site.yml --tags production -i inventories/main/hosts
    ```
4. Monitor logs and metrics for any issues.

---

## 🔗 Related Issues

- Closes issue : [#XX](https://github.com/bingops-com/labops/issues/XX)
- Related to issue : [#XX](https://github.com/bingops-com/labops/issues/XX)

---

## 🙏 Additional Notes

- **Anything else the reviewers should know**: 
- **Screenshots or GIFs to demonstrate the change**:
