### PR TITLE
feat(apps): update kube state metrics ingress by patching manifests by environment

### DIFF
--- a/apps/kube-state-metrics/base/kustomization.yaml
+++ b/apps/kube-state-metrics/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - ingress.yaml

--- a/apps/kube-state-metrics/clusters/preprod/ingress.yaml
+++ b/apps/kube-state-metrics/clusters/preprod/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: kube-metrics.preprod.homelab.local
+    - host: kube-metrics.env.homelab.local
       http:
         paths:
           - path: /

--- a/apps/kube-state-metrics/clusters/preprod/kustomization.yaml
+++ b/apps/kube-state-metrics/clusters/preprod/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - ingress.yaml
 
 labels:
   - pairs:
@@ -16,3 +15,12 @@ helmCharts:
     releaseName: kube-state-metrics
     namespace: monitoring
     valuesFile: values.yaml
+
+patches:
+  - target:
+      kind: Ingress
+      name: kube-metrics-ingress
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: kube-metrics.preprod.homelab.local

--- a/apps/kube-state-metrics/clusters/production/kustomization.yaml
+++ b/apps/kube-state-metrics/clusters/production/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - ingress.yaml
 
 labels:
   - pairs:
@@ -15,3 +14,13 @@ helmCharts:
     version: 5.30.1
     releaseName: kube-state-metrics
     namespace: monitoring
+    valuesFile: values.yaml
+
+patches:
+  - target:
+      kind: Ingress
+      name: kube-metrics-ingress
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: kube-metrics.prod.homelab.local


### PR DESCRIPTION
# 📡 Labops Pull Request Description

## 📋 Description

**Briefly describe the purpose of this PR**: Update kube state metrics ingress object to patch its manifest using kustomize

---

## ⚠️ Points of Attention

Are there any specific aspects that need extra attention?
- **Potential impacts on other features or services**: 
- **Breaking changes or migrations required**: 
- **Dependencies or external services involved**: 

---

## 🧪 How to Test

Procedure to test this PR:
1. Clone the branch and navigate to the project folder.
2. Run the following commands:
    ```sh
    export PROJECT_PATH="/opt/homeops/labops"
    
   # Deploy Kustomize
    kubectl kustomize --enable-helm apps/kube-state-metrics/clusters/preprod | kubectl apply -f -
    ```
3. Check if the new feature/fix works as expected.
4. Confirm that existing features are not impacted.

---

## 🚀 Deployment

Procedure to deploy this PR to production:
1. Merge this PR into the `master` branch.
2. Ensure the CI/CD pipeline completes successfully.
3. Deploy using the following command:
    ```sh
   # Update the master branch
    git checkout master \
      && git pull origin master

    export PROJECT_PATH="/opt/homeops/labops"
   
   # Deploy Kustomize
    kubectl kustomize --enable-helm apps/kube-state-metrics/clusters/production | kubectl apply -f -
    ```
4. Monitor logs and metrics for any issues.

---

## 🔗 Related Issues

- Closes issue : [#XX](https://github.com/bingops-com/labops/issues/XX)
- Related to issue : [#XX](https://github.com/bingops-com/labops/issues/XX)

---

## 🙏 Additional Notes

- **Anything else the reviewers should know**: 
- **Screenshots or GIFs to demonstrate the change**:
