### PR TITLE
fix: patch build workflow to avoid dev images tagged as latest

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           images: ghcr.io/bingops-com/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
+            ${{ matrix.is_pr != 'true' && 'type=raw,value=latest' || '' }}
             type=sha
             type=raw,value=${{ steps.tagprefix.outputs.prefix }}{{date 'YYYYMMDD-HHmmss'}}
 

--- a/docker/blog/Dockerfile
+++ b/docker/blog/Dockerfile
@@ -1,7 +1,11 @@
 FROM docker.io/debian:trixie-slim@sha256:2a68788db17e6f845263ea011a249de9d78394607da22836f107fa033b70882c
 
+# renovate: datasource=node versioning=semver
 ENV NODE_VERSION=23.0.0
+
+# renovate: datasource=github-releases depName=caddyserver/caddy versioning=semver
 ENV CADDY_VERSION=v2.7.6
+
 ENV APP_DIR=/app
 
 USER root

--- a/docker/www/Dockerfile
+++ b/docker/www/Dockerfile
@@ -1,8 +1,12 @@
 FROM docker.io/debian:trixie-slim@sha256:2a68788db17e6f845263ea011a249de9d78394607da22836f107fa033b70882c
 LABEL name="www"
 
+# renovate: datasource=node versioning=semver
 ENV NODE_VERSION=23.0.0
+
+# renovate: datasource=github-releases depName=caddyserver/caddy versioning=semver
 ENV CADDY_VERSION=v2.7.6
+
 ENV APP_DIR=/app
 
 USER root

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["dockerfile", "github-actions"],
+  "enabledManagers": ["dockerfile", "github-actions", "regex"],
   "docker": {
     "enabled": true,
     "pinDigests": true,
@@ -11,7 +11,16 @@
   "github-actions": {
     "enabled": true
   },
+  "regexManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+versioning=(?<versioning>.*?)\\s*\\nENV (?<packageName>.*?)=(?<currentValue>.*)"
+      ]
+    }
+  ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitTypeAll(bump)"
   ]
 }


### PR DESCRIPTION
# 📡 Labops Pull Request Description

## 📋 Description

**Briefly describe the purpose of this PR**: fix the bug on the build-push workflow to avoid tagging dev images as latest

---

## ⚠️ Points of Attention

Are there any specific aspects that need extra attention?
- **Potential impacts on other features or services**: 
- **Breaking changes or migrations required**: 
- **Dependencies or external services involved**: 

---

## 🧪 How to Test

Procedure to test this PR:
1. Clone the branch and navigate to the project folder.
2. Run the following commands:
    ```sh
    Merge PR
    ```
3. Check if the new feature/fix works as expected.
4. Confirm that existing features are not impacted.

---

## 🚀 Deployment

Procedure to deploy this PR to production:
1. Merge this PR into the `master` branch.
2. Ensure the CI/CD pipeline completes successfully.
3. Deploy using the following command:
    ```sh
    Merge PR
    ```
4. Monitor logs and metrics for any issues.

---

## 🔗 Related Issues

- Closes issue : [#XX](https://github.com/bingops-com/labops/issues/XX)
- Related to issue : [#XX](https://github.com/bingops-com/labops/issues/XX)

---

## 🙏 Additional Notes

- **Anything else the reviewers should know**: 
- **Screenshots or GIFs to demonstrate the change**:
