### PR TITLE
fix(authentik): allow Argo CD authorization code flow

### DIFF
--- a/apps/platform/authentik/blueprint.yaml
+++ b/apps/platform/authentik/blueprint.yaml
@@ -27,6 +27,8 @@ data:
           client_type: confidential
           client_id: argocd
           client_secret: !Env AUTHENTIK_ARGOCD_PROD_CLIENT_SECRET
+          grant_types:
+            - authorization_code
           include_claims_in_id_token: true
           issuer_mode: per_provider
           property_mappings:
@@ -54,6 +56,8 @@ data:
           client_type: confidential
           client_id: argocd-test
           client_secret: !Env AUTHENTIK_ARGOCD_TEST_CLIENT_SECRET
+          grant_types:
+            - authorization_code
           include_claims_in_id_token: true
           issuer_mode: per_provider
           property_mappings:


### PR DESCRIPTION
## What changed

Explicitly allow the `authorization_code` grant type on both Authentik providers used by Argo CD.

## Root cause

Authentik 2026.5 introduced per-provider grant type selection. Providers created by the existing blueprint had an empty grant type list, so valid Argo CD authorization requests were rejected as malformed.

## Validation

- parsed the blueprint YAML successfully
- `git diff --check` passed
- live provider inspection confirmed both existing providers currently have an empty grant type list