### PR TITLE
fix(authentik): sign Argo CD tokens with RS256

### DIFF
--- a/apps/platform/authentik/blueprint.yaml
+++ b/apps/platform/authentik/blueprint.yaml
@@ -29,6 +29,7 @@ data:
           client_secret: !Env AUTHENTIK_ARGOCD_PROD_CLIENT_SECRET
           grant_types:
             - authorization_code
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           include_claims_in_id_token: true
           issuer_mode: per_provider
           property_mappings:
@@ -58,6 +59,7 @@ data:
           client_secret: !Env AUTHENTIK_ARGOCD_TEST_CLIENT_SECRET
           grant_types:
             - authorization_code
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           include_claims_in_id_token: true
           issuer_mode: per_provider
           property_mappings:


### PR DESCRIPTION
## What changed

Configure both Authentik Argo CD providers to sign tokens with the existing `authentik Self-signed Certificate`.

## Root cause

Without a signing key, Authentik emitted HS256 tokens. Argo CD validates provider tokens against JWKS and expected RS256, causing token verification to fail after a successful login.

## Validation

- parsed the blueprint YAML successfully
- `git diff --check` passed
- live logs confirmed HS256 was emitted while Argo CD expected RS256