### PR TITLE
fix(arc): ignore controller-owned resources

### DIFF
--- a/apps/gitops/clusters/labprod/github-actions-runner-scale-set.yaml
+++ b/apps/gitops/clusters/labprod/github-actions-runner-scale-set.yaml
@@ -22,6 +22,31 @@ spec:
         controllerServiceAccount:
           namespace: arc-systems
           name: arc-controller
+        resourceMeta:
+          autoscalingListener:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          listenerServiceAccount:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          listenerRole:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          listenerRoleBinding:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          listenerConfigSecret:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          ephemeralRunnerSet:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          ephemeralRunner:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+          ephemeralRunnerConfigSecret:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
         template:
           spec:
             securityContext:

--- a/docs/gitops-applications.md
+++ b/docs/gitops-applications.md
@@ -192,6 +192,11 @@ Administration. A webhook is not required for ARC.
 Rotate the private key in GitHub, replace the Bitwarden value, verify the
 generated Kubernetes Secret keys, then revoke the previous key.
 
+The scale-set chart marks ARC-generated listeners, their support RBAC and
+ephemeral runner resources with Argo CD's `IgnoreExtraneous` comparison option.
+These runtime resources inherit the parent Application tracking label but are
+owned by ARC rather than Helm; Argo CD must neither report nor prune them.
+
 Git declares the `labtest-pr-deployer` ServiceAccount, Role, and RoleBinding in
 `argocd-system`. Its Kubernetes permissions are limited to reading and patching
 Argo CD Applications; it cannot read Secrets or mutate workloads directly.


### PR DESCRIPTION
## Summary

- mark ARC listener and ephemeral runner resources as Argo CD `IgnoreExtraneous`
- prevent Argo CD from pruning controller-owned runtime resources that inherit its tracking label
- document lifecycle ownership

## Root cause

ARC propagates the parent scale set labels to listeners and support RBAC. Argo CD therefore tracked those dynamically generated objects as Helm resources and repeatedly marked/pruned them as extraneous.

## Validation

- `git diff --check`
- `kubectl kustomize apps/gitops/clusters/labprod`
- live validation will use an immutable root override before merge