### PR TITLE
fix(observability): avoid node exporter host port conflict

### DIFF
--- a/apps/gitops/clusters/labprod/monitoring.yaml
+++ b/apps/gitops/clusters/labprod/monitoring.yaml
@@ -202,6 +202,9 @@ spec:
               cpu: 150m
               memory: 128Mi
         prometheus-node-exporter:
+          # Traefik already binds host port 9100 on the single-node cluster.
+          # The ClusterIP Service can scrape node-exporter without hostNetwork.
+          hostNetwork: false
           resources:
             requests:
               cpu: 20m

--- a/apps/gitops/clusters/labtest/monitoring.yaml
+++ b/apps/gitops/clusters/labtest/monitoring.yaml
@@ -202,6 +202,9 @@ spec:
               cpu: 100m
               memory: 96Mi
         prometheus-node-exporter:
+          # Traefik already binds host port 9100 on the single-node cluster.
+          # The ClusterIP Service can scrape node-exporter without hostNetwork.
+          hostNetwork: false
           resources:
             requests:
               cpu: 20m

--- a/docs/infrastructure/observability.md
+++ b/docs/infrastructure/observability.md
@@ -19,6 +19,11 @@ Elasticsearch log stream. The Grafana sidecar discovers it from the
 `grafana-dashboard-labops-operations` ConfigMap; no dashboard is imported from
 an unpinned external URL or maintained manually in Grafana.
 
+Node exporter runs in the Pod network rather than with `hostNetwork`. Traefik
+already binds host port 9100 on each single-node cluster, while Prometheus can
+scrape node exporter through its ClusterIP Service without reserving that host
+port.
+
 Argo CD owns the ECK operator, Elasticsearch resource,
 `kube-prometheus-stack`, Fluent Bit, ingress, RBAC and all configuration.
 Local-path PVCs contain generated operational history rather than source data.


### PR DESCRIPTION
## Summary

- disable node-exporter host networking on labtest and labprod
- keep scraping through the chart-managed ClusterIP Service
- document why port 9100 cannot be reserved on the single-node clusters

## Root cause

The prometheus-node-exporter subchart enables `hostNetwork` by default. Traefik already binds host port 9100 on both clusters, so the node-exporter DaemonSet could not schedule.

## Validation

- `git diff --check`
- kube-prometheus-stack 87.19.0 Helm renders for both environments
- rendered DaemonSets have `hostNetwork: false` and no `hostPort`
- labtest and labprod GitOps Kustomize renders