### PR TITLE
fix(observability): ignore rollout-only deployment status

### DIFF
--- a/apps/gitops/clusters/labprod/monitoring.yaml
+++ b/apps/gitops/clusters/labprod/monitoring.yaml
@@ -7,6 +7,11 @@ metadata:
     argocd.argoproj.io/sync-wave: "-5"
 spec:
   project: labops-labprod
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /status/terminatingReplicas
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack

--- a/apps/gitops/clusters/labtest/monitoring.yaml
+++ b/apps/gitops/clusters/labtest/monitoring.yaml
@@ -7,6 +7,11 @@ metadata:
     argocd.argoproj.io/sync-wave: "-5"
 spec:
   project: labops-labtest
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /status/terminatingReplicas
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack


### PR DESCRIPTION
## Summary

- ignore only `Deployment.status.terminatingReplicas` in both monitoring Applications
- keep Deployment specs fully diffed and reconciled

## Root cause

The Kubernetes API exposes `status.terminatingReplicas`, but the Argo CD structured-diff schema in the current controller does not declare it. This caused a comparison error before the node-exporter host-network fix could apply.

## Validation

- `git diff --check`
- labtest and labprod GitOps Kustomize renders
- the ignored path is limited to Deployment status