### PR TITLE
fix(observability): use compatible monitoring diff

### DIFF
--- a/apps/gitops/clusters/labprod/monitoring.yaml
+++ b/apps/gitops/clusters/labprod/monitoring.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd-system
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
 spec:
   project: labops-labprod
   ignoreDifferences:

--- a/apps/gitops/clusters/labtest/monitoring.yaml
+++ b/apps/gitops/clusters/labtest/monitoring.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd-system
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
 spec:
   project: labops-labtest
   ignoreDifferences:


### PR DESCRIPTION
## Summary

- disable structured server-side diff only for the monitoring Applications
- retain the narrow `Deployment.status.terminatingReplicas` ignore rule

## Root cause

The installed Argo CD diff engine fails while decoding a Kubernetes Deployment status field introduced by the cluster API. Client-side diff avoids that schema mismatch while still reconciling the desired monitoring spec.

## Validation

- `git diff --check`
- labtest and labprod GitOps Kustomize renders