### PR TITLE
fix(labtest): reduce observability memory footprint

### DIFF
--- a/apps/gitops/clusters/labtest/monitoring.yaml
+++ b/apps/gitops/clusters/labtest/monitoring.yaml
@@ -161,10 +161,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 96Mi
+              memory: 64Mi
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 192Mi
         prometheus:
           prometheusSpec:
             externalLabels:
@@ -175,10 +175,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 128Mi
               limits:
                 cpu: 500m
-                memory: 768Mi
+                memory: 512Mi
             serviceMonitorSelectorNilUsesHelmValues: false
             podMonitorSelectorNilUsesHelmValues: false
             ruleSelectorNilUsesHelmValues: false

--- a/apps/gitops/clusters/labtest/traefik.yaml
+++ b/apps/gitops/clusters/labtest/traefik.yaml
@@ -22,6 +22,13 @@ spec:
           kind: DaemonSet
           dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
         podSecurityContext:
           runAsGroup: 0
           runAsNonRoot: false

--- a/apps/platform/observability/labtest/elasticsearch.yaml
+++ b/apps/platform/observability/labtest/elasticsearch.yaml
@@ -24,10 +24,10 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 768Mi
+                  memory: 512Mi
                 limits:
                   cpu: 750m
-                  memory: 1Gi
+                  memory: 768Mi
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data


### PR DESCRIPTION
## Summary

- reduce labtest Elasticsearch container memory to 512Mi request / 768Mi limit
- keep Elasticsearch heap at 384Mi
- reduce labtest Prometheus to 128Mi request / 512Mi limit
- reduce Grafana to 64Mi request / 192Mi limit
- give Traefik an explicit 64Mi request / 128Mi limit

## Root cause

The single labtest node has about 2.7Gi allocatable memory. After observability rollout, Traefik was repeatedly OOM-killed with exit 137 and Argo components became unstable. Production sizing is unchanged.

## Validation

- `git diff --check`
- labtest GitOps Kustomize renders
- labtest observability Kustomize render